### PR TITLE
fix(pkg.files): `utils` 也是重要的文件夹

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   ],
   "files": [
     "src",
+    "utils",
     "index.js",
     "nuxt.js",
     "poi.js"


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why

utils 文件夹不仅仅是摆设，它被 index.js 文件使用，因此不能缺少
