### PR TITLE
fix: 兼容 publicPath 为绝对路径的 url 的情况

### DIFF
--- a/test/utils/correct-path.test.js
+++ b/test/utils/correct-path.test.js
@@ -20,4 +20,22 @@ describe('测试路径拼接', () => {
       'no-slash.com/index.html'
     )
   })
+
+  test('http 开头', () => {
+    expect(correctPath('http://no-slash.com', 'index.html')).toBe(
+      'http://no-slash.com/index.html'
+    )
+  })
+
+  test('https 开头', () => {
+    expect(correctPath('https://no-slash.com', 'index.html')).toBe(
+      'https://no-slash.com/index.html'
+    )
+  })
+
+  test('// 开头', () => {
+    expect(correctPath('//no-slash.com', 'index.html')).toBe(
+      '//no-slash.com/index.html'
+    )
+  })
 })

--- a/utils/index.js
+++ b/utils/index.js
@@ -4,6 +4,7 @@
  */
 
 const path = require('path')
+const url = require('url')
 const pupa = require('./pupa')
 
 exports.join = path.join
@@ -21,7 +22,7 @@ exports.resolveWebpackEntry = (webpackEntry, opts = {}) => {
   if (isObject(webpackEntry)) {
     return {
       ...webpackEntry,
-      [opts.NAME]: opts.filePath
+      [opts.NAME]: opts.filePath,
     }
   }
 
@@ -37,7 +38,7 @@ exports.resolveWebpackEntry = (webpackEntry, opts = {}) => {
   return {
     // 默认 main
     main: webpackEntry,
-    [opts.NAME]: opts.filePath
+    [opts.NAME]: opts.filePath,
   }
 }
 
@@ -54,8 +55,8 @@ exports.replaceStr = (content, replaceStrMap = {}) => {
 exports.correctPath = (publicPath, ...args) => {
   let p = path.join(publicPath, ...args)
 
-  if (publicPath.slice(0, 2) === '//') {
-    p = '/' + p
+  if (publicPath.startsWith('http') || publicPath.startsWith('//')) {
+    p = url.resolve(publicPath, ...args)
   }
 
   return p


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
以前的写法只支持传入相对路径的 publicPath，因为是使用 `path.join()` 进行拼接，所以传入带协议的 url，就会被转换为路径

## How
在原有的基础上，判断 publicPath 是否一个 绝对路径的 url（http 或者 // 开头

如果是，则使用 `url.resolve()` 拼接 url

## Test
![image](https://user-images.githubusercontent.com/27952659/96426301-a66f3180-122f-11eb-9b40-cf977d5cceca.png)
