### PR TITLE
feat: 自动更新版本号

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -45,6 +45,8 @@ yarn add @femessage/update-popup
 UPDATE_POPUP_VERSION=1.0.0 # 如果有必要，可以支持更多位数。如：1.0.0.1，1.0.0.1.1
 ```
 
+你也可以使用 [options.auto](#options.auto) 来实现自动更新版本。
+
 工程配置文件
 
 ```js
@@ -77,6 +79,28 @@ const config = {
 使用独立的 publicPath，一般情况下不需要设置此参数。
 
 [⬆ Back to Top](#table-of-contents)
+
+### options.auto
+
+- Type: `boolean`
+- Default: `false`
+
+是否需要自动更新版本，需要配合 `options.versionType` 一起使用。
+
+**注意**：开启此功能，环境变量 `UPDATE_POPUP_VERSION` 则不会再生效。
+
+### options.versionType
+
+- Type: `'timestamp'`
+- Default: `timestamp`
+
+自动生成的 version 的方式，可选值：
+
+- `timestamp`:
+
+  使用当前时间戳，它看上去是这样的：`1603184005919.0.0`，把时间戳放在版本号的第一位，是为了保证无论如何都会大于已有的版本。
+
+  **注意**：这将失去版本语义化的控制。
 
 ### options.inject
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -45,7 +45,7 @@ yarn add @femessage/update-popup
 UPDATE_POPUP_VERSION=1.0.0 # 如果有必要，可以支持更多位数。如：1.0.0.1，1.0.0.1.1
 ```
 
-你也可以使用 [options.auto](#options.auto) 来实现自动更新版本。
+也可以使用 [options.auto](#options.auto) 来实现自动更新版本。
 
 工程配置文件
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -91,7 +91,7 @@ const config = {
 
 ### options.versionType
 
-- Type: `'timestamp'`
+- Type: `'timestamp' | 未来支持更多`
 - Default: `timestamp`
 
 自动生成的 version 的方式，可选值：

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Use publicPath setting
 - Type: `boolean`
 - Default: `false`
 
-automatic update version，need to configure `options.versionType`.
+set `options.versionType` to make updated version code automatic
 
 **Note**：If true，the environment variable `UPDATE_POPUP_VERSION` No longer takes effect.
 

--- a/README.md
+++ b/README.md
@@ -87,11 +87,11 @@ Use publicPath setting
 
 set `options.versionType` to make updated version code automatic
 
-**Note**：If true，the environment variable `UPDATE_POPUP_VERSION` No longer takes effect.
+**Note**：If true，the environment variable `UPDATE_POPUP_VERSION` doesn't work.
 
 ### options.versionType
 
-- Type: `'timestamp'`
+- Type: `'timestamp' | Support more...`
 - Default: `timestamp`
 
 The way of automatically generated version，values：

--- a/README.md
+++ b/README.md
@@ -45,20 +45,22 @@ Environment variables
 UPDATE_POPUP_VERSION=1.0.0 # Support more. e.g.: 1.0.0.1, 1.0.0.1.1
 ```
 
+You can also use [options.auto](#options.auto) to implement automatic update version.
+
 Project configuration file
 
 ```js
 // nuxt.config.js
 const config = {
-  modules: ['@femessage/update-popup/nuxt', {options}],
+  modules: ['@femessage/update-popup/nuxt', {options}]
 }
 
 // vue.config.js or poi.config.js
 const UpdatePopup = require('@femessage/update-popup')
 const config = {
-  chainWebpack: (config) => {
+  chainWebpack: config => {
     config.plugin('femessage-update-popup').use(UpdatePopup, [{options}])
-  },
+  }
 }
 ```
 
@@ -77,6 +79,28 @@ It's so easy.
 Use publicPath setting
 
 [⬆ Back to Top](#table-of-contents)
+
+### options.auto
+
+- Type: `boolean`
+- Default: `false`
+
+automatic update version，need to configure `options.versionType`.
+
+**Note**：If true，the environment variable `UPDATE_POPUP_VERSION` No longer takes effect.
+
+### options.versionType
+
+- Type: `'timestamp'`
+- Default: `timestamp`
+
+The way of automatically generated version，values：
+
+- `timestamp`:
+
+  Using the current timestamp，it looks like this: `1603184005919.0.0`. it was put in the first place to ensure that it would always be bigger than the previous version.
+
+  **Note**：this will lose the control of version semantics.
 
 ### options.inject
 
@@ -167,6 +191,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@
  *  inject?: boolean
  *  envKey?: string
  *  versionFileName?: string
+ *  auto?: boolean
+ *  versionType?: string
  * }} UpdatePopupOptions
  */
 
@@ -28,6 +30,8 @@ const readFile = filePath => fs.readFileSync(filePath, 'utf8')
 
 const NAME = 'femessage-update-popup'
 
+const VERSION_TYPES = ['timestamp']
+
 class UpdatePopup {
   /** @param {UpdatePopupOptions} options */
   constructor(options) {
@@ -36,12 +40,31 @@ class UpdatePopup {
         publicPath: '',
         inject: true, // 自动注入到 webpack.entry
         envKey: 'UPDATE_POPUP_VERSION',
-        versionFileName: 'update_popup_version.txt'
+        versionFileName: 'update_popup_version.txt',
+        auto: false, // 是否自动生成 version
+        versionType: 'timestamp' // 自动生成的 version 的方式
       },
       options
     )
 
-    this.version = process.env[this.options.envKey] || '1.0.0'
+    if (this.options.auto) {
+      if (!VERSION_TYPES.includes(this.options.versionType)) {
+        console.warn(
+          `Unknown versionType: ${this.options.versionType}. Falling back to timestamp`
+        )
+        this.options.versionType = 'timestamp'
+      }
+
+      switch (this.options.versionType) {
+        case 'timestamp':
+          this.version = `${Date.now()}.0.0`
+          break
+        default:
+          break
+      }
+    } else {
+      this.version = process.env[this.options.envKey] || '1.0.0'
+    }
   }
 
   /** @type {(compiler: import('webpack').Compiler) => void} */

--- a/index.js
+++ b/index.js
@@ -30,7 +30,9 @@ const readFile = filePath => fs.readFileSync(filePath, 'utf8')
 
 const NAME = 'femessage-update-popup'
 
-const VERSION_TYPES = ['timestamp']
+const VERSION_TYPES = {
+  TIMESTAMP: 'timestamp'
+}
 
 class UpdatePopup {
   /** @param {UpdatePopupOptions} options */
@@ -42,7 +44,7 @@ class UpdatePopup {
         envKey: 'UPDATE_POPUP_VERSION',
         versionFileName: 'update_popup_version.txt',
         auto: false, // 是否自动生成 version
-        versionType: 'timestamp' // 自动生成的 version 的方式
+        versionType: VERSION_TYPES.TIMESTAMP // 自动生成的 version 的方式
       },
       options
     )
@@ -50,13 +52,13 @@ class UpdatePopup {
     if (this.options.auto) {
       if (!VERSION_TYPES.includes(this.options.versionType)) {
         console.warn(
-          `Unknown versionType: ${this.options.versionType}. Falling back to timestamp`
+          `Unknown versionType: ${this.options.versionType}. Falling back to ${VERSION_TYPES.TIMESTAMP}`
         )
-        this.options.versionType = 'timestamp'
+        this.options.versionType = VERSION_TYPES.TIMESTAMP
       }
 
       switch (this.options.versionType) {
-        case 'timestamp':
+        case VERSION_TYPES.TIMESTAMP:
           this.version = `${Date.now()}.0.0`
           break
         default:


### PR DESCRIPTION
<!--- 
please use Conventional Commits： https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits
-->

## Why
满足不想手动修改环境变量的情况，故增加一个备选功能：让 update-popup 自动生成 version。

## How
1. 增加 `auto` 和 `versionType` 选项，两者需要配合使用
2. 开启 `auto`，则不会使用 `UPDATE_POPUP_VERSION`
3. 为方便扩展，增加 `versionType`，默认为 `timestamp`：使用当前时间戳作为版本（这将会失去版本语义化的控制
4. 把时间戳放在版本号的第一位，是为了保证无论如何都会大于已有的版本（之前的语义化版本）。

## Docs

- [x] README.md
- [x] README-zh.md
