### PR TITLE
fix: windows build 分隔符处理 /

### DIFF
--- a/utils/index.js
+++ b/utils/index.js
@@ -3,6 +3,7 @@
  * @typedef {{[k:string]: any}} obj
  */
 
+const os = require('os')
 const path = require('path')
 const url = require('url')
 const pupa = require('./pupa')
@@ -54,6 +55,10 @@ exports.replaceStr = (content, replaceStrMap = {}) => {
  */
 exports.correctPath = (publicPath, ...args) => {
   let p = path.join(publicPath, ...args)
+  // Windows_NT 系统 替换分隔符 '\' -> '/' 
+  if (os.type().indexOf('Windows') != -1) {
+    p = p.split(path.sep).join('/')
+  }
 
   if (publicPath.startsWith('http') || publicPath.startsWith('//')) {
     p = url.resolve(publicPath, ...args)


### PR DESCRIPTION
## Why
windows 环境下 执行 ``` npm run build ``` 会解析路径失败
linux 下能正常执行
需要对window分隔符处理 ‘\’ 替换 ‘/’ 
